### PR TITLE
Check that Content-Type header exists before running a regexp on it

### DIFF
--- a/twix.js
+++ b/twix.js
@@ -53,7 +53,8 @@ var Twix = (function () {
         client.onreadystatechange = function() {
             if (this.readyState == 4 && this.status == 200) {
                 var data = this.responseText;
-                if (this.getResponseHeader('Content-Type').match(/json/)) {
+                var contentType = this.getResponseHeader('Content-Type');
+                if (contentType && contentType.match(/json/)) {
                     data = JSON.parse(this.responseText);
                 }
                 options.success(data, this.statusText, this);


### PR DESCRIPTION
I ran into a situation where a server was not returning a Content-Type, and the match check was failing. It failed with an exception, which kept my success function from calling.
